### PR TITLE
Update to JupyterLab v4.0.13

### DIFF
--- a/.github/workflows/upgrade-jupyterlab-dependencies.yml
+++ b/.github/workflows/upgrade-jupyterlab-dependencies.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install required dependencies
         run: |
-          python -m pip install requests pre-commit
+          python -m pip install requests
           sudo apt-get install hub
 
       - name: Install Node
@@ -78,7 +78,6 @@ jobs:
             git config user.name "JupyterLab Desktop Bot"
             git config user.email 'jupyterlab-bot@users.noreply.github.com'
 
-            pre-commit run
             git commit . -m "Update to JupyterLab v${LATEST}"
 
             git push --set-upstream origin "${BRANCH_NAME}"            

--- a/scripts/upgrade-lab-dependencies.py
+++ b/scripts/upgrade-lab-dependencies.py
@@ -42,6 +42,7 @@ def update_package_json(new_version):
 
         with open(path, 'w') as file:
             json.dump(existing_package_json, file, indent=2)
+            file.write('\n') 
 
 
 def update_dependencies(existing_json, new_json):


### PR DESCRIPTION
New JupyterLab release [v](https://github.com/jupyterlab/jupyterlab/releases/tag/) is available. Please review the lock file carefully..